### PR TITLE
Make output text red on error and major bug fix

### DIFF
--- a/app/src/main/java/Resources/EncryptionDetails.java
+++ b/app/src/main/java/Resources/EncryptionDetails.java
@@ -96,8 +96,7 @@ public class EncryptionDetails {
         return "• Base64 Encoding: Vigenere64 combines Vigenere cipher techniques with Base64 encoding, providing an extra layer of obfuscation. The message and key are both encoded in Base64 before encryption and decoded after decryption.\n\n" +
                 "• Symmetric Encryption: Like the Vigenere cipher, Vigenere64 uses a key that is repeated (or cycled) over the length of the message. The same key is used for both encryption and decryption, making key management essential.\n\n" +
                 "• Variable Key Length: The key can be of any length, but during encryption, the key is cycled to match the length of the message. This allows flexibility in the key size.\n\n" +
-                "• Incremental Shift: The encryption process involves shifting characters of the Base64-encoded message by the combined index of the corresponding message character and key character, plus the position in the message, making the encryption more complex.\n\n" +
-                "• Non-standard Algorithm: Vigenere64 is an experimental hybrid encryption method and does not meet modern cryptographic standards. Its security relies on obfuscation rather than robust cryptographic principles, making it unsuitable for securing sensitive information.\n\n" +
-                "• Key Generation: A random Base64-encoded key can be generated using UUIDs, ensuring a unique key for each encryption process, though the security of the key generation mechanism is not as robust as standard cryptographic practices.";
+                "• Incremental Shift: The encryption process involves shifting characters of the Base64-encoded message by the combined index of the corresponding message character and key character, plus both the position and the length of the message, making the encryption more complex.\n\n" +
+                "• Non-standard Algorithm: Vigenere64 is an experimental hybrid encryption method and does not meet modern cryptographic standards. Its security relies on obfuscation rather than robust cryptographic principles, making it unsuitable for securing sensitive information.\n\n";
     }
 }

--- a/app/src/main/java/com/example/e_mazing/DecryptActivity.java
+++ b/app/src/main/java/com/example/e_mazing/DecryptActivity.java
@@ -1,5 +1,6 @@
 package com.example.e_mazing;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -80,9 +81,12 @@ public class DecryptActivity extends AppCompatActivity {
                 String output = "";
                 String key = txtKey.getText().toString();
                 String message = txtMessage.getText().toString();
+                txtOutput.setTextColor(Color.BLACK);
+                int errorColor = Color.parseColor("#AA0000");
 
                 if (key.isEmpty()) {
                     txtOutput.setText("Empty key");
+                    txtOutput.setTextColor(errorColor);
                     return;
                 }
 
@@ -92,6 +96,7 @@ public class DecryptActivity extends AppCompatActivity {
                             output = AES.decrypt(key, message);
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);
@@ -102,6 +107,7 @@ public class DecryptActivity extends AppCompatActivity {
                             output = RSA.decrypt(key, message);
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);
@@ -111,6 +117,7 @@ public class DecryptActivity extends AppCompatActivity {
                             output = DES.decrypt(key, message);
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);
@@ -120,6 +127,7 @@ public class DecryptActivity extends AppCompatActivity {
                             output = Blowfish.decrypt(key, message);
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);
@@ -129,6 +137,7 @@ public class DecryptActivity extends AppCompatActivity {
                             output = Vigenere64.decrypt(key, message);
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);

--- a/app/src/main/java/com/example/e_mazing/EncryptActivity.java
+++ b/app/src/main/java/com/example/e_mazing/EncryptActivity.java
@@ -1,5 +1,7 @@
 package com.example.e_mazing;
 
+import android.content.res.ColorStateList;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -77,6 +79,8 @@ public class EncryptActivity extends AppCompatActivity {
                 String output = "";
                 String key = txtKey.getText().toString();
                 String message = txtMessage.getText().toString();
+                txtOutput.setTextColor(Color.BLACK);
+                int errorColor = Color.parseColor("#AA0000");
 
                 switch ((int) spinnerEncrypt.getSelectedItemId()) {
                     case 0:
@@ -89,6 +93,7 @@ public class EncryptActivity extends AppCompatActivity {
                             output = AES.encrypt(key, message);
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);
@@ -109,6 +114,7 @@ public class EncryptActivity extends AppCompatActivity {
                             output += keyInfo;
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);
@@ -123,6 +129,7 @@ public class EncryptActivity extends AppCompatActivity {
                             output = DES.encrypt(key, message);
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);
@@ -137,6 +144,7 @@ public class EncryptActivity extends AppCompatActivity {
                             output = Blowfish.encrypt(key, message);
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);
@@ -151,6 +159,7 @@ public class EncryptActivity extends AppCompatActivity {
                             output = Vigenere64.encrypt(key, message);
                         } catch (Exception e) {
                             output = e.getMessage();
+                            txtOutput.setTextColor(errorColor);
                         }
 
                         txtOutput.setText(output);

--- a/app/src/main/java/com/example/e_mazing/Vigenere64.java
+++ b/app/src/main/java/com/example/e_mazing/Vigenere64.java
@@ -17,7 +17,7 @@ public class Vigenere64 {
 
             int messageIndex = charset.indexOf(message.charAt(i));
             int keyIndex = charset.indexOf(key.charAt(i % key.length()));
-            int resultIndex = (messageIndex + keyIndex + i) % charset.length();
+            int resultIndex = (messageIndex + keyIndex + i + message.length()) % charset.length();
             result += charset.charAt(resultIndex);
         }
 
@@ -36,7 +36,13 @@ public class Vigenere64 {
 
             int messageIndex = charset.indexOf(message.charAt(i));
             int keyIndex = charset.indexOf(key.charAt(i % key.length()));
-            int resultIndex = (messageIndex - keyIndex - i + charset.length()) % charset.length();
+            int resultIndex = (messageIndex - keyIndex - i - message.length());
+
+            while (resultIndex < 0) {
+                resultIndex += charset.length();
+            }
+
+            resultIndex %= charset.length();
             result += charset.charAt(resultIndex);
         }
 
@@ -44,6 +50,14 @@ public class Vigenere64 {
     }
 
     public static String generateKey() throws Exception {
-        return Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
+        String result = "";
+        Random random = new Random();
+
+        for (int i = 0; i < 8; i++) {
+            int index = random.nextInt(charset.length());
+            result += charset.charAt(index);
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
## Changes
- [Make output text red on error](https://github.com/ionvop/E-Mazing/commit/54c1b4f36ed57ec7289c6d69e56fe1cc9aa8b235)

### Minor changes
- [Updated Vigenere64 feature description](https://github.com/ionvop/E-Mazing/commit/420fdcd1a07ad7b9784c0d8c6af253499861907c)
- [Reduced the generated key length for Vigenere64](https://github.com/ionvop/E-Mazing/commit/9cb708fd4494619a93ea1b48249599ab81763a27)
- [Improved encryption by including message length](https://github.com/ionvop/E-Mazing/commit/9cb708fd4494619a93ea1b48249599ab81763a27)

### Bug fixes
- [Fixed ArrayIndexOutOfBoundsException caused by negative index result](https://github.com/ionvop/E-Mazing/commit/9cb708fd4494619a93ea1b48249599ab81763a27)